### PR TITLE
Create a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ SHELL := bash
 # (3) copy src/ontology files to release directory and update IRIs
 # (4) copy catalog to release directory and update IRIs
 # (5) create a merged RO core.owl with annotations
-# (6) copy iao.owl to release directory and update import IRIs
-# (7) merge imports and reason to create iao-merged.owl
+# (6) copy iao.owl to release directory, update imports, and reason
+# (7) merge iao.owl with imports to create iao-merged.owl
 # (8) clean build files
 
 # If you wish to keep build/robot.jar, run `make release` instead.
@@ -118,7 +118,9 @@ $(TARGET)/iao.owl: $(SRC)/iao.owl | $(IAO_COMPS) catalog build/robot.jar
 	@echo "Copying iao.owl to $(TARGET)" && \
 	sed -e 's#/obo/iao/dev#/obo/iao/$(DATE)#g' $< | \
 	sed -e 's#ro/core#iao/$(DATE)/ro/core#g' > $@ && \
-	robot annotate --input $@ --version-iri $(V)/iao.owl
+	robot reason --input $@ --create-new-ontology false\
+	 --annotate-inferred-axioms false \
+	annotate --version-iri $(V)/iao.owl --output $@
 
 # merge all components then reason
 # set ontology and version IRIs
@@ -126,6 +128,5 @@ merged: $(MERGED)
 $(MERGED): $(TARGET)/iao.owl | build/robot.jar
 	@echo "Merging release" && \
 	robot merge --input $< --collapse-import-closure true \
-	reason --create-new-ontology false --annotate-inferred-axioms false \
 	annotate --ontology-iri $(OBO)/iao/iao-merged.owl\
 	 --version-iri $(V)/iao-merged.owl --output $@

--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,14 @@ clean: | release
 # ===============================
 
 .PHONY: $(RO)/bfo-axioms.owl
-$(RO)/bfo-axioms.owl: $(RO)
+$(RO)/bfo-axioms.owl: $(RO) | build/robot.jar
 	@echo "Downloading $@" && \
 	curl -Ls $(OBO)/ro/bfo-axioms.owl > $@ && \
 	$(ROBOT) annotate --input $@ --ontology-iri $(OBO)/iao/$@\
 	 --version-iri $(OBO)/iao/$(DATE)/ro/bfo-axioms.owl --output $@
 
 .PHONY: $(RO)/bfo-classes-minimal.owl
-$(RO)/bfo-classes-minimal.owl: $(RO)
+$(RO)/bfo-classes-minimal.owl: $(RO) | build/robot.jar
 	@echo "Downloading $@" && \
 	curl -Ls $(OBO)/ro/bfo-classes-minimal.owl > $@ && \
 	$(ROBOT) annotate --input $@ --ontology-iri $(OBO)/iao/$@\

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build $(RO) $(TARGET):
 # download the most recent build of ROBOT
 build/robot.jar: | build
 	@echo "Getting ROBOT" && \
-	curl -Ls https://build.berkeleybop.org/job/robot/lastSuccessfulBuild/artifact/bin/robot.jar> $@
+	curl -Ls https://github.com/ontodev/robot/releases/download/v1.2.0/robot.jar > $@
 
 clean: | release
 	@echo "Removing build files" && \

--- a/Makefile
+++ b/Makefile
@@ -68,25 +68,18 @@ clean: | release
 #            RO TASKS
 # ===============================
 
+$(RO)/bfo-axioms.owl: $(RO)
+	@echo "Downloading $@" && \
+	curl -Ls $(OBO)/ro/bfo-axioms.owl > $@
+
+$(RO)/bfo-classes-minimal.owl: $(RO)
+	@echo "Downloading $@" && \
+	curl -Ls $(OBO)/ro/bfo-classes-minimal.owl > $@
+
 RO_CORE = $(RO)/core.owl
-# bfo axioms and bfo classes minimal are already included in core
-# right now we just need to get the annotations
-ANNOTATIONS = annotations.owl
-
-# download RO annotations
-.PHONY: $(ANNOTATIONS)
-$(ANNOTATIONS): $(RO)
-	@echo "Downloading RO $@" && \
-	curl -Ls $(OBO)/ro/$@ > $(RO)/$@
-
-# get RO core by IRI and add annotations
-.PHONY: $(RO_CORE)
-$(RO_CORE): $(ANNOTATIONS) | build/robot.jar
-	@echo "Generating $@" && \
-	$(ROBOT) merge --input-iri $(OBO)/ro/core.owl\
-	 --input $(RO)/annotations.owl --collapse-import-closure true \
-	annotate --ontology-iri $(OBO)/ro/core.owl \
-	 --version-iri $(V)/ro/core.owl --output $@
+$(RO_CORE): $(RO)/bfo-axioms.owl $(RO)/bfo-classes-minimal.owl
+	@echo "Downloading $@" && \
+	curl -Ls $(OBO)/ro/core.owl > $@
 
 # ===============================
 #           IAO TASKS
@@ -133,7 +126,7 @@ $(IAO_COMPS): $(TARGET) | $(TARGET)/iao-main.owl build/robot.jar
 
 # move the generated release files to the release dir
 move: $(SRC)/iao-merged.owl $(SRC)/iao.owl $(RO) | $(IAO_COMPS)
-	@echo "Moving $^ to $(TARGET)" && \
+	@echo "Copying $^ to $(TARGET)" && \
 	cp $< $(TARGET)/iao-merged.owl && \
 	cp $(word 2,$^) $(TARGET)/iao.owl && \
 	cp -R $(word 3,$^) $(TARGET)/ro

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,131 @@
+# config
+MAKEFLAGS += --warn-undefined-variables
+SHELL := bash
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := all
+.DELETE_ON_ERROR:
+.SUFFIXES:
+.SECONDARY:
+
+# Run `make all` to create a new IAO release:
+# (1) download the latest build of ROBOT
+# (2) create a new release directory
+# (3) copy src/ontology files to release directory and update IRIs
+# (4) copy catalog to release directory and update IRIs
+# (5) create a merged RO core.owl with annotations
+# (6) copy iao.owl to release directory and update import IRIs
+# (7) merge imports and reason to create iao-merged.owl
+# (8) clean build files
+
+# If you wish to keep build/robot.jar, run `make release` instead.
+
+# ===============================
+#           VARIABLES
+# ===============================
+
+OBO = http://purl.obolibrary.org/obo
+ROBOT = java -jar build/robot.jar
+
+# directories
+SRC = src/ontology
+TARGET = releases/$(DATE)
+
+# release vars
+TS = $(shell date +'%m:%d:%Y %H:%M')
+DATE = $(shell date +'%Y-%m-%d')
+V = $(OBO)/iao/$(DATE)
+
+# dependencies & targets
+CAT = catalog-v001.xml 
+MERGED = $(TARGET)/iao-merged.owl
+RO = $(TARGET)/ro
+
+# ===============================
+#           MAIN TASKS
+# ===============================
+
+# run `make all` or `make release` to make a new release
+# `make all` will remove the build dir with ROBOT on completion
+all: release clean
+release: merged
+	@echo "A new release is available in $(TARGET)"
+
+# various directories
+build $(RO) $(TARGET):
+	@mkdir $@
+
+# ===============================
+#             ROBOT
+# ===============================
+
+build/robot.jar: | build
+	@echo "Getting ROBOT" && \
+	curl -Ls https://build.berkeleybop.org/job/robot/lastSuccessfulBuild/artifact/bin/robot.jar> $@
+
+clean: merged
+	@echo "Removing build files" && \
+	rm -rf build
+
+# ===============================
+#            RO TASKS
+# ===============================
+
+RO_CORE = $(RO)/core.owl
+# bfo axioms and bfo classes minimal are already included in core
+# right now we just need to get the annotations
+RO_COMPS = annotations.owl
+
+ro: $(RO_CORE)
+
+$(RO_COMPS): $(RO)
+	@echo "Downloading RO $@" && \
+	curl -Ls $(OBO)/ro/$@ > $(RO)/$@
+
+$(RO_CORE): $(RO_COMPS) | build/robot.jar
+	@echo "Generating $@" && \
+	$(ROBOT) merge --input-iri $(OBO)/ro/core.owl\
+	 --input $(RO)/annotations.owl --collapse-import-closure true \
+	annotate --version-iri $(V)/ro/core.owl --output $@
+
+# ===============================
+#           IAO TASKS
+# ===============================
+
+IAO_COMPS = externalByHand.owl \
+ iao-main.owl \
+ import-OBO.owl \
+ obsolete.owl \
+ ontology-metadata.owl
+
+# move the IAO components to the release dir and set the version IRI
+$(IAO_COMPS): $(TARGET) | build/robot.jar
+	@echo "Copying $@ to $<" && \
+	$(ROBOT) annotate --input $(SRC)/$@\
+	 --version-iri $(V)/$@ --output $(TARGET)/$@
+
+# move the catalog file to the release dir
+# make sure the IRIs are correct
+# add the RO core mapping
+catalog: $(TARGET)/$(CAT)
+$(TARGET)/$(CAT): $(SRC)/$(CAT) ro | $(TARGET)
+	@echo "Copying catalog to $(TARGET)" && \
+	sed -e 's#/iao/dev/#/iao/$(DATE)/#g' $< | \
+	sed -e '$$i\'$$'\n''<uri name="$(V)/ro/core.owl" uri="ro/core.owl"/>' > $@
+
+# move the main file to the release dir
+# make sure the IRIs are correct and set version IRI
+$(TARGET)/iao.owl: $(SRC)/iao.owl | $(IAO_COMPS) catalog build/robot.jar
+	@echo "Copying iao.owl to $(TARGET)" && \
+	sed -e 's#/obo/iao/dev#/obo/iao/$(DATE)#g' $< | \
+	sed -e 's#ro/core#iao/$(DATE)/ro/core#g' > $@ && \
+	robot annotate --input $@ --version-iri $(V)/iao.owl
+
+# merge all components then reason
+# set ontology and version IRIs
+merged: $(MERGED)
+$(MERGED): $(TARGET)/iao.owl | build/robot.jar
+	@echo "Merging release" && \
+	robot merge --input $< --collapse-import-closure true \
+	reason --create-new-ontology false --annotate-inferred-axioms false \
+	annotate --ontology-iri $(OBO)/iao/iao-merged.owl\
+	 --version-iri $(V)/iao-merged.owl --output $@

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -14,4 +14,5 @@
         <uri name="http://purl.obolibrary.org/obo/iao/dev/iao-main.owl" uri="iao-main.owl"/>
         <uri name="http://purl.obolibrary.org/obo/iao/dev/import-OBO.owl" uri="import-OBO.owl"/>
         <uri name="http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl" uri="ontology-metadata.owl"/>
+        <uri name="http://purl.obolibrary.org/obo/iao/dev/ro/core.owl" uri="ro/core.owl"/>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -14,5 +14,7 @@
         <uri name="http://purl.obolibrary.org/obo/iao/dev/iao-main.owl" uri="iao-main.owl"/>
         <uri name="http://purl.obolibrary.org/obo/iao/dev/import-OBO.owl" uri="import-OBO.owl"/>
         <uri name="http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl" uri="ontology-metadata.owl"/>
-        <uri name="http://purl.obolibrary.org/obo/iao/dev/ro/core.owl" uri="ro/core.owl"/>
+        <uri name="http://purl.obolibrary.org/obo/ro/core.owl" uri="ro/core.owl"/>
+        <uri name="http://purl.obolibrary.org/obo/ro/bfo-axioms.owl" uri="ro/bfo-axioms.owl"/>
+        <uri name="http://purl.obolibrary.org/obo/ro/bfo-classes-minimal.owl" uri="ro/bfo-classes-minimal.owl"/>
 </catalog>

--- a/src/ontology/iao-main.owl
+++ b/src/ontology/iao-main.owl
@@ -19,7 +19,7 @@
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/import-OBO.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/externalByHand.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/ro/core.owl"/>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/ro/core.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <dc:contributor xml:lang="en">Mathias Brochhausen</dc:contributor>
         <dc:contributor xml:lang="en">Pat Hayes</dc:contributor>

--- a/src/ontology/iao-main.owl
+++ b/src/ontology/iao-main.owl
@@ -19,7 +19,7 @@
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/import-OBO.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/externalByHand.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/dev/ro/core.owl"/>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/ro/core.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <dc:contributor xml:lang="en">Mathias Brochhausen</dc:contributor>
         <dc:contributor xml:lang="en">Pat Hayes</dc:contributor>


### PR DESCRIPTION
Add a Makefile for IAO release process.

Use `make all` or `make release` to create the release directory and all required components. This Makefile utilizes [ROBOT](http://robot.obolibrary.org/), but you do not need to install it (the process grabs the latest version automatically).