### PR TITLE
259 add 'orcid identifier'

### DIFF
--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -4005,7 +4005,7 @@ Data were captured into EPI-DATA (version 3.1), cleaned and then exported to Sta
         <dc:creator rdf:resource="http://orcid.org/0000-0002-1595-3213"/>
         <oboInOwl:hasExactSynonym>ORCID ID</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ORCID id</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>ORCID identifier</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Open Researcher and Contributor ID</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Open Researcher and Contributor Identifier</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>iD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">ORCID identifier</rdfs:label>

--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -3998,31 +3998,18 @@ Data were captured into EPI-DATA (version 3.1), cleaned and then exported to Sta
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000708">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000578"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115>A &apos;centrally registered identifier&apos; that is issued by ORCID (https://orcid.org/) and used to persistantly identify oneself as a human researcher or contributor.</obo:IAO_0000115>
-        <obo:IAO_0000116>&quot;You can connect your iD with your professional information — affiliations, grants, publications, peer review, and more. You can use your iD to share your information with other systems, ensuring you get recognition for all your contributions, saving you time and hassle, and reducing the risk of errors.&quot;</obo:IAO_0000116>
+        <obo:IAO_0000115>A centrally registered identifier that is issued by ORCID (https://orcid.org/) and used to persistantly identify oneself as a human researcher or contributor.</obo:IAO_0000115>
+        <obo:IAO_0000116>&quot;You can connect your iD with your professional information — affiliations, grants, publications, peer review, and more. You can use your iD to share your information with other systems, ensuring you get recognition for all your contributions, saving you time and hassle, and reducing the risk of errors.&quot; [https://orcid.org/]</obo:IAO_0000116>
         <obo:IAO_0000116>This class was originally defined in Apollo_SV (http://purl.obolibrary.org/obo/APOLLO_SV_00000496) but due to it being more in scope of IAO, it was decided to add it to IAO and deprecate its Apollo_SV equivalent. (2022-10-25)</obo:IAO_0000116>
+        <obo:IAO_0000117>http://orcid.org/0000-0002-1595-3213</obo:IAO_0000117>
+        <obo:IAO_0000118>ORCID ID</obo:IAO_0000118>
+        <obo:IAO_0000118>ORCiD</obo:IAO_0000118>
+        <obo:IAO_0000118>Open Researcher and Contributor ID</obo:IAO_0000118>
+        <obo:IAO_0000118>Open Researcher and Contributor Identifier</obo:IAO_0000118>
+        <obo:IAO_0000119>https://orcid.org/</obo:IAO_0000119>
         <obo:IAO_0000233>https://github.com/information-artifact-ontology/IAO/issues/259</obo:IAO_0000233>
-        <dc:creator rdf:resource="http://orcid.org/0000-0002-1595-3213"/>
-        <oboInOwl:hasExactSynonym>ORCID ID</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>ORCID id</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>Open Researcher and Contributor ID</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>Open Researcher and Contributor Identifier</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>iD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">ORCID identifier</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000708"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>A &apos;centrally registered identifier&apos; that is issued by ORCID (https://orcid.org/) and used to persistantly identify oneself as a human researcher or contributor.</owl:annotatedTarget>
-        <obo:IAO_0000119>https://orcid.org/</obo:IAO_0000119>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000708"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget>&quot;You can connect your iD with your professional information — affiliations, grants, publications, peer review, and more. You can use your iD to share your information with other systems, ensuring you get recognition for all your contributions, saving you time and hassle, and reducing the risk of errors.&quot;</owl:annotatedTarget>
-        <dc:source>https://orcid.org/</dc:source>
-    </owl:Axiom>
-
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020000 -->

--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -3993,6 +3993,38 @@ Data were captured into EPI-DATA (version 3.1), cleaned and then exported to Sta
 
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000708 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000708">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000578"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115>A &apos;centrally registered identifier&apos; that is issued by ORCID (https://orcid.org/) and used to persistantly identify oneself as a human researcher or contributor.</obo:IAO_0000115>
+        <obo:IAO_0000116>&quot;You can connect your iD with your professional information — affiliations, grants, publications, peer review, and more. You can use your iD to share your information with other systems, ensuring you get recognition for all your contributions, saving you time and hassle, and reducing the risk of errors.&quot;</obo:IAO_0000116>
+        <obo:IAO_0000116>This class was originally defined in Apollo_SV (http://purl.obolibrary.org/obo/APOLLO_SV_00000496) but due to it being more in scope of IAO, it was decided to add it to IAO and deprecate its Apollo_SV equivalent. (2022-10-25)</obo:IAO_0000116>
+        <obo:IAO_0000233>https://github.com/information-artifact-ontology/IAO/issues/259</obo:IAO_0000233>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-1595-3213"/>
+        <oboInOwl:hasExactSynonym>ORCID ID</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ORCID id</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ORCID identifier</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Open Researcher and Contributor Identifier</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>iD</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">ORCID identifier</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000708"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A &apos;centrally registered identifier&apos; that is issued by ORCID (https://orcid.org/) and used to persistantly identify oneself as a human researcher or contributor.</owl:annotatedTarget>
+        <obo:IAO_0000119>https://orcid.org/</obo:IAO_0000119>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000708"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
+        <owl:annotatedTarget>&quot;You can connect your iD with your professional information — affiliations, grants, publications, peer review, and more. You can use your iD to share your information with other systems, ensuring you get recognition for all your contributions, saving you time and hassle, and reducing the risk of errors.&quot;</owl:annotatedTarget>
+        <dc:source>https://orcid.org/</dc:source>
+    </owl:Axiom>
+
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0020000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0020000">


### PR DESCRIPTION
This PR adds the class 'ORCID identifier' as a subclass of 'centrally registered identifier' (IAO:0000578) with the details provided in the related NTR issue (closes #259).



@zhengj2007 as I wrote in the [issue comments](https://github.com/information-artifact-ontology/IAO/issues/259#issuecomment-1290097396), I took what I assume to be the next free ID (IAO_0000708). Having some documentation on what IDs are allowed to use for external contributions would be great for future external PRs. And my Protégé default is to use dc:creator insted of IAO:'term editor' for the attribution. Let me know, if this needs to be changed. I also had to do the edits in my texteditor, as saving it in Protégé would have caused a much bigger diff, due to its automatic sorting. Maybe you can do this automatic sorting with the next release, so contributing in the future will be easier?

- [ ] If this PR is accepted and merged, [APOLLO_SV_00000496](http://purl.obolibrary.org/obo/APOLLO_SV_00000496) (ORCID) should be deprecated and its user base needs to be informed about the deprecation. ( @hoganwr?)