### PR TITLE
Add historic documentation for IAO:0000098 (data format specification)

### DIFF
--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -1338,6 +1338,7 @@ XML document; The instructions in a XSD file&quot;</obo:IAO_0000116>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000187</obo:IAO_0000119>
         <rdfs:label xml:lang="en">data format specification</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://github.com/information-artifact-ontology/IAO/issues/172"/>
     </owl:Class>
     
 

--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -1337,8 +1337,8 @@ XML document; The instructions in a XSD file&quot;</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PlanAndPlannedProcess Branch</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000187</obo:IAO_0000119>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/IAO/issues/172"/>
         <rdfs:label xml:lang="en">data format specification</rdfs:label>
-        <rdfs:seeAlso rdf:resource="https://github.com/information-artifact-ontology/IAO/issues/172"/>
     </owl:Class>
     
 


### PR DESCRIPTION
This PR adds a IAO_0000233 (term tracker item) annotation to data format specification, as [alanruttenberg](https://github.com/alanruttenberg) commented [Oct 15, 2016](https://github.com/information-artifact-ontology/IAO/issues/172#issuecomment-254012333) that an editor note would help the documentation of this term.