### PR TITLE
Add new term IAO:0000651 `title section`

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run ontology QC checks
         env:
           DEFAULT_BRANCH: master
-        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=false
+        run: make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=false

--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -33,6 +33,7 @@
         <dc:contributor xml:lang="en">Barry Smith</dc:contributor>
         <dc:contributor xml:lang="en">Bjoern Peters</dc:contributor>
         <dc:contributor xml:lang="en">Carlo Torniai</dc:contributor>
+        <dc:contributor xml:lang="en">Charles Tapley Hoyt</dc:contributor>
         <dc:contributor xml:lang="en">Chris Mungall</dc:contributor>
         <dc:contributor xml:lang="en">Chris Stoeckert</dc:contributor>
         <dc:contributor xml:lang="en">Christian A. Boelling</dc:contributor>
@@ -3868,6 +3869,19 @@ Data were captured into EPI-DATA (version 3.1), cleaned and then exported to Sta
         <rdfs:isDefinedBy rdf:resource="https://github.com/information-artifact-ontology/IAO"/>
         <rdfs:label xml:lang="en">database extract, transform, and load process</rdfs:label>
         <foaf:page rdf:resource="https://en.wikipedia.org/wiki/Extract,_transform,_load"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000651 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000651">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000314"/>
+        <obo:IAO_0000115 xml:lang="en">the section of the document where the title appears</obo:IAO_0000115>
+        <obo:IAO_0000116>This term should not be confused with dc:title - this term represents the component of the document where the title appears, and not the value of the title itself.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Charles Tapley Hoyt</obo:IAO_0000117>
+        <obo:IAO_0000233 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/information-artifact-ontology/IAO/issues/286</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">title section</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/iao-edit.owl
+++ b/src/ontology/iao-edit.owl
@@ -3878,7 +3878,7 @@ Data were captured into EPI-DATA (version 3.1), cleaned and then exported to Sta
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000651">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000314"/>
         <obo:IAO_0000115 xml:lang="en">the section of the document where the title appears</obo:IAO_0000115>
-        <obo:IAO_0000116>This term should not be confused with dc:title - this term represents the component of the document where the title appears, and not the value of the title itself.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">This term should not be confused with dc:title - this term represents the component of the document where the title appears, and not the value of the title itself.</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">Charles Tapley Hoyt</obo:IAO_0000117>
         <obo:IAO_0000233 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/information-artifact-ontology/IAO/issues/286</obo:IAO_0000233>
         <rdfs:label xml:lang="en">title section</rdfs:label>


### PR DESCRIPTION
Closes #286 

This pull request adds IAO:0000651 `title section` as a subclass of [document part (IAO:0000314)](https://www.ebi.ac.uk/ols4/ontologies/iao/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FIAO_0000314?lang=en) to complement `abstract`, `methods section`, etc. as a place where text can come from.

This is useful for me to create a reusable data model for NER, to say where text came from in a document that got annotated.

This is not the same thing as `dcterms:title`, which is about the value itself, and not the location within a document.